### PR TITLE
Fix load file location

### DIFF
--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -3,7 +3,7 @@ meta:
   name         : plantdis
   title        : Detect plant disease from an image of a leaf.
   keywords     : transfer learning, tensorflow, deep learning, plant disease, python
-  version      : 0.1.1
+  version      : 0.1.2
   languages    : py
   license      : gpl3
   author       : u7156387@anu.edu.au

--- a/mlhub/diagnose.py
+++ b/mlhub/diagnose.py
@@ -5,6 +5,7 @@ import warnings
 #taking the file path from command line
 import argparse
 import re
+import os
 
 # Ensure paths are relative to the user's cwd.
 
@@ -23,8 +24,6 @@ f_path = args.file_path
 if(not re.search(pattern,f_path.lower())):
     raise Exception("Please add proper image extension")
     # f_path = 'test/' + f_path
-
-import os
 
 # checking if the file exists
 assert os.path.exists(f_path), "The file could not be found, "+str(f_path)

--- a/mlhub/diagnose.py
+++ b/mlhub/diagnose.py
@@ -6,6 +6,12 @@ import warnings
 import argparse
 import re
 
+# Ensure paths are relative to the user's cwd.
+
+from mlhub.pkg import get_cmd_cwd
+os.chdir(get_cmd_cwd())
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-v","--view",action="store_true")
 parser.add_argument("file_path")


### PR DESCRIPTION
When mlhub runs a script it runs the script in ~/.mlhub/plantdis and so if a filename is supplied it is generally not going to be found in there. The `mlhub` package provides get_cmd_cwd() to handle this.