### PR TITLE
Enhance segmentation and detection process

### DIFF
--- a/ui_dev/flutter_test_application_1/lib/services/plant_service.dart
+++ b/ui_dev/flutter_test_application_1/lib/services/plant_service.dart
@@ -181,7 +181,7 @@ class PlantService {
     if (kDebugMode)
       print('[_runAnalysis] Starting for plant: $plantId, image: $imageId');
     try {
-      // 1. Check if the image file exists
+      // Check if the image file exists
       io.File inputFile = imageFile;
 
       try {

--- a/ui_dev/flutter_test_application_1/lib/services/segmentation_service.dart
+++ b/ui_dev/flutter_test_application_1/lib/services/segmentation_service.dart
@@ -179,7 +179,7 @@ class SegmentationService {
       inputOrt.release();
       runOptions.release();
 
-      if (kDebugMode) print('[SegmentationService] Segmentation done: ${outFile.path}');
+      if (kDebugMode) print('[SegmentationService] Segmentation done, the result image is in: ${outFile.path}');
 
       // 8. Return the output mask file
       return outFile;

--- a/ui_dev/flutter_test_application_1/lib/views/pages/segment_page.dart
+++ b/ui_dev/flutter_test_application_1/lib/views/pages/segment_page.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test_application_1/models/plant_model.dart'; // Import P
 import 'package:flutter_test_application_1/services/plant_service.dart'; // Import PlantService
 import 'package:flutter_test_application_1/utils/ui_utils.dart'; // Import UIUtils
 import 'dart:async'; // Import for TimeoutException
-import '../services/openrouter_service.dart';
+import 'dart:io' as io;
 
 class SegmentPage extends StatefulWidget {
   const SegmentPage({
@@ -201,6 +201,42 @@ class _SegmentPageState extends State<SegmentPage> {
                         spacing: 10.0,
                         children: [
                           SegmentHero(imgSrc: widget.imgSrc, id: widget.id),
+
+                          // Check for segmentation result in analysisResults
+                          if (hasResults &&
+                              analysisResults!['segmentationUrl'] != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 15.0),
+                              child: Card(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(15.0),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Center(
+                                        child: Text(
+                                          "Segmentation Result",
+                                          style: KTextStyle.titleTealText,
+                                        ),
+                                      ),
+                                      SizedBox(height: 15),
+                                      ClipRRect(
+                                        borderRadius: BorderRadius.circular(
+                                          5.0,
+                                        ),
+                                        child: Image.network(
+                                          analysisResults!['segmentationUrl'],
+                                          width: double.infinity,
+                                          fit: BoxFit.cover,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+
                           Container(
                             width: double.infinity,
                             padding: EdgeInsets.symmetric(vertical: 10.0),

--- a/ui_dev/flutter_test_application_1/lib/views/widgets/segment_hero_widget.dart
+++ b/ui_dev/flutter_test_application_1/lib/views/widgets/segment_hero_widget.dart
@@ -1,37 +1,80 @@
+import 'dart:io';
 import 'package:easy_image_viewer/easy_image_viewer.dart';
 import 'package:flutter/material.dart';
 
 class SegmentHero extends StatelessWidget {
-  const SegmentHero({super.key, required this.imgSrc, required this.id});
+  const SegmentHero({
+    super.key,
+    required this.imgSrc,
+    required this.id,
+    this.segmentationFile,
+  });
 
   final String imgSrc;
   final String id;
+  final File? segmentationFile;
 
   @override
   Widget build(BuildContext context) {
     return Hero(
       tag: id,
-      child: AspectRatio(
-        aspectRatio: 16 / 9,
-        child: GestureDetector(
-          onTap: () {
-            showImageViewer(
-              context,
-              Image.network(imgSrc).image,
-              swipeDismissible: true,
-              doubleTapZoomable: true,
-              onViewerDismissed: () {},
-            );
-          },
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(5.0),
-            child: Image.network(
-              imgSrc,
-              width: double.infinity,
-              fit: BoxFit.cover,
+      child: Column(
+        children: [
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: GestureDetector(
+              onTap: () {
+                showImageViewer(
+                  context,
+                  Image.network(imgSrc).image,
+                  swipeDismissible: true,
+                  doubleTapZoomable: true,
+                  onViewerDismissed: () {},
+                );
+              },
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(5.0),
+                child: Image.network(
+                  imgSrc,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+              ),
             ),
           ),
-        ),
+
+          // Display segmentation result if available
+          if (segmentationFile != null) ...[
+            SizedBox(height: 10),
+            Text(
+              "Segmentation Result",
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            SizedBox(height: 5),
+            AspectRatio(
+              aspectRatio: 16 / 9,
+              child: GestureDetector(
+                onTap: () {
+                  showImageViewer(
+                    context,
+                    Image.file(segmentationFile!).image,
+                    swipeDismissible: true,
+                    doubleTapZoomable: true,
+                    onViewerDismissed: () {},
+                  );
+                },
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(5.0),
+                  child: Image.file(
+                    segmentationFile!,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/ui_dev/flutter_test_application_1/lib/views/widgets/segment_widget.dart
+++ b/ui_dev/flutter_test_application_1/lib/views/widgets/segment_widget.dart
@@ -1,19 +1,49 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:easy_image_viewer/easy_image_viewer.dart';
 
 class SegmentWidget extends StatelessWidget {
-  const SegmentWidget({super.key, required this.imgSrc});
+  final File segmentationFile;
+  final String title;
 
-  final String imgSrc;
+  const SegmentWidget({
+    Key? key,
+    required this.segmentationFile,
+    this.title = 'Segmentation Result',
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Hero(
-      tag: 'segmentHero',
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(5.0),
-        child: Image.asset(
-          imgSrc,
-          width: double.infinity,
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 10),
+            GestureDetector(
+              onTap: () {
+                showImageViewer(
+                  context,
+                  Image.file(segmentationFile).image,
+                  swipeDismissible: true,
+                  doubleTapZoomable: true,
+                );
+              },
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(5.0),
+                child: Image.file(
+                  segmentationFile,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/ui_dev/flutter_test_application_1/pubspec.lock
+++ b/ui_dev/flutter_test_application_1/pubspec.lock
@@ -584,6 +584,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  onnxruntime:
+    dependency: "direct main"
+    description:
+      name: onnxruntime
+      sha256: e77ec05acafc135cc5fe7bcdf11b101b39f06513c9d5e9fa02cb1929f6bac72a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
   path:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
This PR refactors the inference workflow to run segmentation first, then feed the masked output into the detection model. It adds a new SegmentationService and updates `PlantService._runAnalysis` accordingly:

1. New file `lib/services/segmentation_service.dart`:

    1. Defines SegmentationService

    2. Loads the ONNX segmentation model

    3. Runs inference on an input image

    4. Returns the original image with non-mask regions removed, preserving only the leaf area

2. Updated file lib/services/plant_service.dart

    In `Future<_> _runAnalysis(...)`:

    1. Pass original image to `SegmentationService.segment(...)`

    2. Receive masked output (leaf-only image)

    3. Feed masked image into detection pipeline instead of raw input

##  What’s Changed
* SegmentationService

    * Model loading & session initialization

    * Mask-to-image composition logic

* PlantService

    * Swapped order of segmentation and detection

    * Updated imports and method calls

## Testing
* Segmentation only
```
final segService = SegmentationService();
final leafOnly = await segService.segment(testLeafImage);
expect(leafOnly, isNotNull);
// Verify non-leaf pixels are transparent or black
```

* End-to-end

    * Run the app with a sample leaf image

    * Confirm that detection highlights only on the segmented leaf region

    * Compare against previous raw-input detection for accuracy improvements

## Impact
* Cleaner pipeline

* Improved detection accuracy by removing background noise

* Modularized segmentation logic for easier reuse and testing

## Related Issues
Closes #62 